### PR TITLE
feat: add CreateDocumentDialog component for document upload functionality

### DIFF
--- a/src/app/company/document/component/CreateDocumentDialog.tsx
+++ b/src/app/company/document/component/CreateDocumentDialog.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useState, useRef, ChangeEvent } from "react";
+import {useCreateDocument} from "@/app/company/document/hooks/useCreateDocument";
+
+export function CreateDocumentDialog() {
+    const [open, setOpen] = useState(false);
+    const [formData, setFormData] = useState({
+        document_name: "",
+        document_type: "",
+        file: null as File | null,
+    });
+    const [errors, setErrors] = useState<Record<string, string>>({});
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const { createDocument, isLoading } = useCreateDocument();
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        setFormData(prev => ({ ...prev, [name]: value }));
+        if (errors[name]) {
+            setErrors(prev => ({ ...prev, [name]: "" }));
+        }
+    };
+
+    const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+        if (e.target.files && e.target.files[0]) {
+            setFormData(prev => ({ ...prev, file: e.target.files![0] }));
+            if (errors.file) {
+                setErrors(prev => ({ ...prev, file: "" }));
+            }
+        }
+    };
+
+    const validateForm = () => {
+        const newErrors: Record<string, string> = {};
+        if (!formData.document_name.trim()) newErrors.document_name = "Document name is required";
+        if (!formData.document_type.trim()) newErrors.document_type = "Document type is required";
+        if (!formData.file) newErrors.file = "File is required";
+
+        setErrors(newErrors);
+        return Object.keys(newErrors).length === 0;
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        if (!validateForm()) return;
+
+        try {
+            const newDocument = {
+                ...formData,
+                id: Math.floor(Math.random() * 10000), // Temporary ID
+                created_at: new Date().toISOString(),
+            };
+
+            await createDocument({
+                ...newDocument,
+                file: newDocument.file ?? undefined,
+            });
+
+            setOpen(false);
+            setFormData({ document_name: "", document_type: "", file: null });
+            if (fileInputRef.current) fileInputRef.current.value = "";
+        } catch (error) {
+            console.error("Failed to create document:", error);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+                <Button variant="outline">Add Document</Button>
+            </DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Upload New Document</DialogTitle>
+                </DialogHeader>
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="document_name">Document Name</Label>
+                        <Input
+                            id="document_name"
+                            name="document_name"
+                            value={formData.document_name}
+                            onChange={handleChange}
+                        />
+                        {errors.document_name && (
+                            <p className="text-sm text-red-500">{errors.document_name}</p>
+                        )}
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="document_type">Document Type</Label>
+                        <Input
+                            id="document_type"
+                            name="document_type"
+                            value={formData.document_type}
+                            onChange={handleChange}
+                        />
+                        {errors.document_type && (
+                            <p className="text-sm text-red-500">{errors.document_type}</p>
+                        )}
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="file">File</Label>
+                        <Input
+                            id="file"
+                            type="file"
+                            ref={fileInputRef}
+                            onChange={handleFileChange}
+                            className="cursor-pointer"
+                            accept=".pdf, .xls, .xlsx, .csv, .md, .txt"
+                        />
+                        {errors.file && (
+                            <p className="text-sm text-red-500">{errors.file}</p>
+                        )}
+                        {formData.file && (
+                            <p className="text-sm text-gray-600">Selected: {formData.file.name}</p>
+                        )}
+                    </div>
+
+                    <div className="flex justify-end gap-2">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => setOpen(false)}
+                            disabled={isLoading}
+                        >
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={isLoading}>
+                            {isLoading ? "Uploading..." : "Upload Document"}
+                        </Button>
+                    </div>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/app/company/document/hooks/useCreateDocument.ts
+++ b/src/app/company/document/hooks/useCreateDocument.ts
@@ -1,0 +1,62 @@
+// hooks/useCreateDocument.ts
+import { useState } from "react";
+import {CompanyDocumentType} from "@/app/company/document/type/CompanyDocumentType";
+
+export const useCreateDocument = () => {
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const createDocument = async (documentData: Omit<CompanyDocumentType, 'id' | 'created_at'> & {
+        id?: number,
+        created_at?: string
+    }) => {
+        setIsLoading(true);
+        setError(null);
+
+        try {
+            // Simulate API call with file upload
+            console.log("Preparing to upload document...");
+            console.log("Document data:", {
+                ...documentData,
+                file: documentData.file ? documentData.file.name : "No file",
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 1500));
+
+            // In a real app, this would be:
+            // const formData = new FormData();
+            // formData.append('document_name', documentData.document_name);
+            // formData.append('document_type', documentData.document_type);
+            // if (documentData.file) {
+            //   formData.append('file', documentData.file);
+            // }
+            //
+            // const response = await fetch('/api/documents', {
+            //   method: 'POST',
+            //   body: formData,
+            // });
+            //
+            // if (!response.ok) throw new Error('Upload failed');
+            //
+            // const data = await response.json();
+
+            const newDocument: CompanyDocumentType = {
+                ...documentData,
+                id: documentData.id || Math.floor(Math.random() * 10000),
+                created_at: documentData.created_at || new Date().toISOString(),
+                file_url: URL.createObjectURL(documentData.file!), // For demo purposes
+            };
+
+            console.log("Document uploaded successfully:", newDocument);
+            return newDocument;
+        } catch (err) {
+            setError("Failed to upload document");
+            console.error("Error uploading document:", err);
+            throw err;
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return { createDocument, isLoading, error };
+};

--- a/src/app/company/document/section/DocumentTableSection.tsx
+++ b/src/app/company/document/section/DocumentTableSection.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import {useFetchDocuments} from "@/app/company/document/hooks/useFetchDocument";
+import {CreateDocumentDialog} from "@/app/company/document/component/CreateDocumentDialog";
 
 const DocumentTableSection = () => {
     const { documents, loading, error } = useFetchDocuments();
@@ -17,7 +18,7 @@ const DocumentTableSection = () => {
         <div className="flex flex-col w-full gap-4">
             <div className="flex w-full justify-between items-center">
                 <h2 className="text-lg font-bold">Documents</h2>
-                <Button variant="outline">Add Document</Button>
+                <CreateDocumentDialog/>
             </div>
 
             <Table>

--- a/src/app/company/document/type/CompanyDocumentType.ts
+++ b/src/app/company/document/type/CompanyDocumentType.ts
@@ -2,5 +2,7 @@ export type CompanyDocumentType = {
     id: number;
     document_name: string;
     document_type: string;
+    file?: File;
+    file_url?: string; // For displaying existing files
     created_at: string;
 }


### PR DESCRIPTION
This pull request introduces a new feature for uploading documents through a dialog interface, along with related changes to support this functionality. The most important changes include adding the `CreateDocumentDialog` component, implementing a custom hook for handling document creation, and integrating the dialog into the document table section.

### New Feature: Document Upload Dialog

* **`CreateDocumentDialog` component**: Added a new component to provide a dialog interface for uploading documents. The dialog includes form validation, file input handling, and integration with the document creation hook.

* **`useCreateDocument` hook**: Implemented a custom hook to handle the logic for creating documents, including simulating an API call, managing loading states, and handling errors.

### Integration with Document Table

* **Integration of `CreateDocumentDialog`**: Replaced the "Add Document" button in the `DocumentTableSection` with the new `CreateDocumentDialog` component to enable the upload functionality. [[1]](diffhunk://#diff-31c1674e347ee63936a7b7aad3141dcc984ef5759cd41ee494268133f5bcfcfaR8) [[2]](diffhunk://#diff-31c1674e347ee63936a7b7aad3141dcc984ef5759cd41ee494268133f5bcfcfaL20-R21)

### Type Updates

* **`CompanyDocumentType` updates**: Extended the `CompanyDocumentType` type to include optional `file` and `file_url` properties for handling file uploads and displaying existing files.